### PR TITLE
Update LimeSuite to the latest version

### DIFF
--- a/sdrangel/Dockerfile
+++ b/sdrangel/Dockerfile
@@ -238,7 +238,7 @@ ARG nb_cores
 WORKDIR /opt/build
 RUN git clone https://github.com/myriadrf/LimeSuite.git \
     && cd LimeSuite \
-    && git reset --hard "v19.01.0" \
+    && git reset --hard "v20.01.0" \
     && mkdir builddir; cd builddir \
     && cmake -Wno-dev -DCMAKE_INSTALL_PREFIX=/opt/install/LimeSuite .. \
     && make -j${nb_cores} install


### PR DESCRIPTION
The latest LimeSuite version v20.01.0 includes the required LimeRFE headers for the image to build successfully 