### PR TITLE
removed the startup of ssh server (it isn't there anymore) 

### DIFF
--- a/sdrangel/start_gui.sh
+++ b/sdrangel/start_gui.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-sudo service ssh start
 sudo service dbus start
-sudo service avahi-daemon start
 IPADDR=$(ip addr show type veth | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b" | head -1)
 export LD_LIBRARY_PATH=/opt/install/libsdrplay/lib:/opt/install/xtrx-images/lib:/opt/install/uhd/lib
 # Drop to a shell when exiting SDRangel

--- a/sdrangel/start_server.sh
+++ b/sdrangel/start_server.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-sudo service ssh start
 sudo service dbus start
-sudo service avahi-daemon start
 IPADDR=$(ip addr show type veth | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b" | head -1)
 export LD_LIBRARY_PATH=/opt/install/libsdrplay/lib:/opt/install/xtrx-images/lib
 # Drop to a shell when exiting SDRangel


### PR DESCRIPTION
also the scripts are trying to start the avahi daemon which isn't there and that also gives an error. I removed both.

BTW sdrangel complains for the lack of avahi apparently: 
**[ERROR] avahi_service_browser_new() failed: Bad state**           

but nevertheless at the startup it gives
" avahi-daemon: unrecognized service"  being the daemon actually not there.