### PR TITLE
reintroduced the avahi service and removed ssh from the startup script

### DIFF
--- a/sdrangel/Dockerfile
+++ b/sdrangel/Dockerfile
@@ -39,6 +39,7 @@ RUN sudo apt-get update && sudo apt-get -y install \
     libtool \
     libfftw3-dev \
     wget \
+    avahi-utils \
     libusb-1.0-0-dev \
     libusb-dev
 

--- a/sdrangel/start_gui.sh
+++ b/sdrangel/start_gui.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-sudo service ssh start
 sudo service dbus start
 sudo service avahi-daemon start
 IPADDR=$(ip addr show type veth | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b" | head -1)

--- a/sdrangel/start_server.sh
+++ b/sdrangel/start_server.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-sudo service ssh start
 sudo service dbus start
 sudo service avahi-daemon start
 IPADDR=$(ip addr show type veth | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b" | head -1)


### PR DESCRIPTION
Running sdrangel complained about being unable to find avahi daemon, which indeed wasn't in the image.
It was probably removed along with wget by not installing openssh-server anymore.

I reintroduced it and there are no more startup errors about avahi. I also removed the ssh related startup command which is not needed any longer.