### PR TITLE
Fix useradd: UID 0 is not unique

### DIFF
--- a/sdrangel/Dockerfile
+++ b/sdrangel/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Create a user with sudo rights
 RUN apt-get update && apt-get -y install sudo
-RUN useradd -m sdr -u ${uid} && echo "sdr:sdr" | chpasswd \
+RUN useradd -o -m sdr -u ${uid} && echo "sdr:sdr" | chpasswd \
    && adduser sdr sudo \
    && usermod -a -G audio,dialout,plugdev sdr\
    && sudo usermod --shell /bin/bash sdr


### PR DESCRIPTION
Got this error when running ./build_vanilla.sh
```
 => [base 2/18] RUN apt-get update && apt-get -y install sudo                                                          13.8s
 => ERROR [base 3/18] RUN useradd -m sdr -u 0 && echo "sdr:sdr" | chpasswd    && adduser sdr sudo    && usermod -a -G   1.9s
------
 > [base 3/18] RUN useradd -m sdr -u 0 && echo "sdr:sdr" | chpasswd    && adduser sdr sudo    && usermod -a -G audio,dialout,plugdev sdr   && sudo usermod --shell /bin/bash sdr:
#7 1.303 useradd: UID 0 is not unique
------
executor failed running [/bin/sh -c useradd -m sdr -u ${uid} && echo "sdr:sdr" | chpasswd    && adduser sdr sudo    && usermod -a -G audio,dialout,plugdev sdr   && sudo usermod --shell /bin/bash sdr]: exit code: 4

```

The -o parameter will [allow the creation of a user account with a duplicate (non-unique) UID.](https://linux.die.net/man/8/useradd)
This resolved the problem.