### PR TITLE
Fix permissions on scripts

### DIFF
--- a/sdrangel/Dockerfile
+++ b/sdrangel/Dockerfile
@@ -400,7 +400,7 @@ COPY --from=xtrx --chown=sdr /opt/install /opt/install
 COPY --from=libmirisdr --chown=sdr /opt/install /opt/install
 COPY --from=uhd --chown=sdr /opt/install /opt/install
 # This is to allow sharing pulseaudio with the host
-COPY pulse-client.conf /etc/pulse/client.conf
+COPY --chmod=644 pulse-client.conf /etc/pulse/client.conf
 
 FROM base AS sdrangel_clone
 ARG branch
@@ -447,8 +447,8 @@ COPY --from=bladerf --chown=sdr /opt/install/libbladeRF/fpga /opt/install/sdrang
 # The final "vanilla" GUI version with no particular hardware dependencies
 FROM gui AS vanilla
 # Start SDRangel and some more services on which SDRangel depends
-COPY start_gui.sh /start.sh
-COPY restart_gui.sh /home/sdr/restart.sh
+COPY --chmod=755 start_gui.sh /start.sh
+COPY --chmod=755 restart_gui.sh /home/sdr/restart.sh
 WORKDIR /home/sdr
 ENTRYPOINT ["/start.sh"]
 
@@ -460,8 +460,8 @@ ADD NVIDIA-DRIVER.run /tmp/NVIDIA-DRIVER.run
 RUN sudo sh /tmp/NVIDIA-DRIVER.run -s --ui=none --no-kernel-module --install-libglvnd --no-questions
 RUN sudo rm /tmp/NVIDIA-DRIVER.run
 # Start SDRangel and some more services on which SDRangel depends
-COPY start_gui.sh /start.sh
-COPY restart_gui.sh /home/sdr/restart.sh
+COPY --chmod=755 start_gui.sh /start.sh
+COPY --chmod=755 restart_gui.sh /home/sdr/restart.sh
 WORKDIR /home/sdr
 ENTRYPOINT ["/start.sh"]
 
@@ -495,7 +495,7 @@ RUN cmake -Wno-dev -DDEBUG_OUTPUT=ON -DRX_SAMPLE_24BIT=${rx_24bits} -DBUILD_GUI=
     && make -j${nb_cores} install
 COPY --from=bladerf --chown=sdr /opt/install/libbladeRF/fpga /opt/install/sdrangel
 # Start SDRangel and some more services on which SDRangel depends
-COPY start_server.sh /start.sh
-COPY restart_server.sh /home/sdr/restart.sh
+COPY --chmod=755 start_server.sh /start.sh
+COPY --chmod=755 restart_server.sh /home/sdr/restart.sh
 WORKDIR /home/sdr
 ENTRYPOINT ["/start.sh"]

--- a/sdrangel/armv8.alpine.Dockerfile
+++ b/sdrangel/armv8.alpine.Dockerfile
@@ -357,7 +357,7 @@ COPY --from=xtrx --chown=sdr /opt/install /opt/install
 COPY --from=libmirisdr --chown=sdr /opt/install /opt/install
 COPY --from=uhd --chown=sdr /opt/install /opt/install
 # This is the first step to allow sharing pulseaudio with the host
-COPY pulse-client.conf /etc/pulse/client.conf
+COPY --chmod=644 pulse-client.conf /etc/pulse/client.conf
 
 FROM base AS sdrangel_clone
 WORKDIR /opt/build
@@ -402,7 +402,7 @@ RUN cmake -Wno-dev -DDEBUG_OUTPUT=ON -DBUILD_TYPE=RELEASE -DRX_SAMPLE_24BIT=${rx
     && make -j${nb_cores} install
 COPY --from=bladerf --chown=sdr /opt/install/libbladeRF/fpga /opt/install/sdrangel
 # Start SDRangel and some more services on which SDRangel depends
-COPY start_server.armv8.sh /start.sh
-COPY restart_server.armv8.sh /home/sdr/restart.sh
+COPY --chmod=755 start_server.armv8.sh /start.sh
+COPY --chmod=755 restart_server.armv8.sh /home/sdr/restart.sh
 WORKDIR /home/sdr
 ENTRYPOINT ["/start.sh"]

--- a/sdrangel/armv8.ubuntu.Dockerfile
+++ b/sdrangel/armv8.ubuntu.Dockerfile
@@ -380,7 +380,7 @@ COPY --from=xtrx --chown=sdr /opt/install /opt/install
 COPY --from=libmirisdr --chown=sdr /opt/install /opt/install
 COPY --from=uhd --chown=sdr /opt/install /opt/install
 # This is to allow sharing pulseaudio with the host
-COPY --chmod=755 pulse-client.conf /etc/pulse/client.conf
+COPY --chmod=644 pulse-client.conf /etc/pulse/client.conf
 
 FROM base AS sdrangel_clone
 ARG branch

--- a/sdrangel/armv8.ubuntu.Dockerfile
+++ b/sdrangel/armv8.ubuntu.Dockerfile
@@ -380,7 +380,7 @@ COPY --from=xtrx --chown=sdr /opt/install /opt/install
 COPY --from=libmirisdr --chown=sdr /opt/install /opt/install
 COPY --from=uhd --chown=sdr /opt/install /opt/install
 # This is to allow sharing pulseaudio with the host
-COPY pulse-client.conf /etc/pulse/client.conf
+COPY --chmod=755 pulse-client.conf /etc/pulse/client.conf
 
 FROM base AS sdrangel_clone
 ARG branch
@@ -432,8 +432,8 @@ RUN sudo sed -i '/X11Forwarding/c\X11Forwarding yes' /etc/ssh/sshd_config \
 # The final "vanilla" GUI version with no particular hardware dependencies
 FROM gui AS vanilla
 # Start SDRangel and some more services on which SDRangel depends
-COPY start_gui.sh /start.sh
-COPY restart_gui.sh /home/sdr/restart.sh
+COPY --chmod=755 start_gui.sh /start.sh
+COPY --chmod=755 restart_gui.sh /home/sdr/restart.sh
 WORKDIR /home/sdr
 ENTRYPOINT ["/start.sh"]
 
@@ -445,8 +445,8 @@ ADD NVIDIA-DRIVER.run /tmp/NVIDIA-DRIVER.run
 RUN sudo sh /tmp/NVIDIA-DRIVER.run -s --ui=none --no-kernel-module --install-libglvnd --no-questions
 RUN sudo rm /tmp/NVIDIA-DRIVER.run
 # Start SDRangel and some more services on which SDRangel depends
-COPY start_gui.sh /start.sh
-COPY restart_gui.sh /home/sdr/restart.sh
+COPY --chmod=755 start_gui.sh /start.sh
+COPY --chmod=755 restart_gui.sh /home/sdr/restart.sh
 WORKDIR /home/sdr
 ENTRYPOINT ["/start.sh"]
 
@@ -481,7 +481,7 @@ RUN cmake -Wno-dev -DDEBUG_OUTPUT=ON -DBUILD_TYPE=RELEASE -DRX_SAMPLE_24BIT=${rx
     && make -j${nb_cores} install
 COPY --from=bladerf --chown=sdr /opt/install/libbladeRF/fpga /opt/install/sdrangel
 # Start SDRangel and some more services on which SDRangel depends
-COPY start_server.sh /start.sh
-COPY restart_server.sh /home/sdr/restart.sh
+COPY --chmod=755 start_server.sh /start.sh
+COPY --chmod=755 restart_server.sh /home/sdr/restart.sh
 WORKDIR /home/sdr
 ENTRYPOINT ["/start.sh"]

--- a/wsjtx/Dockerfile
+++ b/wsjtx/Dockerfile
@@ -77,6 +77,6 @@ RUN DESTDIR="/opt/install/libfaketime" PREFIX="" make install
 FROM base as final
 COPY --from=wsjtx --chown=wsjtx /opt/install /opt/install
 COPY --from=libfaketime --chown=wsjtx /opt/install /opt/install
-COPY start.sh /start.sh
+COPY --chmod=755 start.sh /start.sh
 ENV LD_PRELOAD="/opt/install/libfaketime/lib/faketime/libfaketime.so.1"
 ENTRYPOINT ["/start.sh"]


### PR DESCRIPTION
The COPY statements creates files for the root user by default.

In case that the user running on the host does not have any group or other permissons set (umask 077) this ends up in the script owned by root but without any read or exec permission for the sdr user inside the docker container.

So explicitely set the file mode for script files.