### PR TITLE
Fixing 2 Dockerfile for Raspberry Pi usage

### DIFF
--- a/sdrangel/Dockerfile
+++ b/sdrangel/Dockerfile
@@ -222,10 +222,11 @@ RUN mkdir -p /opt/install/libsdrplay/include \
     && mkdir -p /opt/install/libsdrplay/lib \
     && mkdir -p /opt/build/sdrplay
 RUN cd sdrplay \
-    && wget https://www.sdrplay.com/software/SDRplay_RSP_API-Linux-${SDRPLAY_MAJ}${SDRPLAY_MIN}.run \
     && export ARCH=`arch` \
-    && sh ./SDRplay_RSP_API-Linux-${SDRPLAY_MAJ}${SDRPLAY_MIN}.run --tar xvf \
-    && cp ${ARCH}/libmirsdrapi-rsp.so.${SDRPLAY_MAJ} /opt/install/libsdrplay/lib/. \
+    && export CHECK_ARCH=$(if [ "$ARCH" = "aarch64" ]; then echo "ARM64"; else echo "Linux"; fi) \
+    && wget https://www.sdrplay.com/software/SDRplay_RSP_API-${CHECK_ARCH}-${SDRPLAY_MAJ}${SDRPLAY_MIN}.run \
+    && sh ./SDRplay_RSP_API-${CHECK_ARCH}-${SDRPLAY_MAJ}${SDRPLAY_MIN}.run --tar xvf \
+    && if [ "$CHECK_ARCH" = "Linux" ]; then cp ${ARCH}/libmirsdrapi-rsp.so.${SDRPLAY_MAJ} /opt/install/libsdrplay/lib/.; else cp libmirsdrapi-rsp.so.${SDRPLAY_MAJ} /opt/install/libsdrplay/lib/.; fi \
     && chmod 644 /opt/install/libsdrplay/lib/libmirsdrapi-rsp.so.${SDRPLAY_MAJ} \
     && ln -s /opt/install/libsdrplay/lib/libmirsdrapi-rsp.so.${SDRPLAY_MAJ} /opt/install/libsdrplay/lib/libmirsdrapi-rsp.so.2 \
     && ln -s /opt/install/libsdrplay/lib/libmirsdrapi-rsp.so.2 /opt/install/libsdrplay/lib/libmirsdrapi-rsp.so \

--- a/sdrangelcli/Dockerfile
+++ b/sdrangelcli/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:16-slim as base
+FROM node:18-slim as base
+
+# Set environment variable for Node.js to use legacy OpenSSL provider
+ENV NODE_OPTIONS=--openssl-legacy-provider
 
 # Install base packages
 RUN apt-get update && apt-get -y install sudo git
@@ -22,10 +25,10 @@ ARG clone_label
 RUN git clone https://github.com/f4exb/sdrangelcli.git -b ${branch} sdrangelcli \
     && echo "${clone_label}" > /dev/null
 WORKDIR /opt/build/sdrangelcli
-RUN npm install \
-    && ng build --configuration production \
-    && mv dist /opt/build \
-    && rm -rf *
+RUN npm install
+RUN ng build --configuration production
+RUN mv dist /opt/build
+RUN rm -rf *
 
 WORKDIR /opt/build/dist/sdrangelcli
 ENTRYPOINT [ "http-server" ]


### PR DESCRIPTION
Angular CLI (for sdrangelcli) requires Node.js v18.13, so changed node:16-slim but this breaks OpenSSL 3 so added openssl-legacy-provider
sdrangel does not check if its compiling on a ARM64, so SDRplay fails. Made some checks that downloads the correct version.